### PR TITLE
Add minimal emergency Face ID app

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { View, Text, Button, StyleSheet, Linking } from 'react-native';
+import * as LocalAuthentication from 'expo-local-authentication';
+
+export default function App() {
+  const [authenticated, setAuthenticated] = React.useState(false);
+
+  const handleLogin = async () => {
+    const result = await LocalAuthentication.authenticateAsync({
+      promptMessage: 'Authenticate with Face ID',
+      fallbackLabel: 'Enter passcode',
+      disableDeviceFallback: false,
+    });
+
+    if (result.success) {
+      setAuthenticated(true);
+    }
+  };
+
+  const handleCall = () => {
+    Linking.openURL('tel:112');
+  };
+
+  return (
+    <View style={styles.container}>
+      {!authenticated ? (
+        <Button title="Login with Face ID" onPress={handleLogin} />
+      ) : (
+        <>
+          <Text style={styles.text}>Authenticated!</Text>
+          <Button title="Call Emergency" onPress={handleCall} />
+        </>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    marginBottom: 20,
+    fontSize: 18,
+  },
+});

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Emergency Face ID App
+
+This is a minimal React Native example using Expo. The app authenticates the user via Face ID and calls the emergency number when the button is pressed after authentication.
+
+## Running
+
+1. Install dependencies with `npm install`.
+2. Start the Expo development server with `npm start`.
+3. Run the app on your device or emulator using the Expo Go app.
+
+The emergency number dialed is set to `112`. You can change this in `App.js`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "emergency-face-id-app",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "^50.0.17",
+    "expo-local-authentication": "~14.2.1",
+    "react": "18.1.0",
+    "react-native": "0.72.4"
+  }
+}


### PR DESCRIPTION
## Summary
- add a React Native example using expo-local-authentication
- provide a README with instructions
- create package.json with dependencies

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68541cdb2a00832da43a0fb14a9f84d9