### PR TITLE
Add GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npx expo export --platform web --output-dir web-build
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./web-build
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v2
+        id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+web-build/

--- a/App.js
+++ b/App.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { View, Text, Button, StyleSheet, Linking } from 'react-native';
+import * as LocalAuthentication from 'expo-local-authentication';
+
+export default function App() {
+  const [authenticated, setAuthenticated] = React.useState(false);
+
+  const handleLogin = async () => {
+    const result = await LocalAuthentication.authenticateAsync({
+      promptMessage: 'Authenticate with Face ID',
+      fallbackLabel: 'Enter passcode',
+      disableDeviceFallback: false,
+    });
+
+    if (result.success) {
+      setAuthenticated(true);
+    }
+  };
+
+  const handleCall = () => {
+    Linking.openURL('tel:112');
+  };
+
+  return (
+    <View style={styles.container}>
+      {!authenticated ? (
+        <Button title="Login with Face ID" onPress={handleLogin} />
+      ) : (
+        <>
+          <Text style={styles.text}>Authenticated!</Text>
+          <Button title="Call Emergency" onPress={handleCall} />
+        </>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    marginBottom: 20,
+    fontSize: 18,
+  },
+});

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Emergency Face ID App
+
+This is a minimal React Native example using Expo. The app authenticates the user via Face ID and calls the emergency number when the button is pressed after authentication.
+
+## Running
+
+1. Install dependencies with `npm install`.
+2. Start the Expo development server with `npm start`.
+3. Run the app on your device or emulator using the Expo Go app.
+
+## GitHub Pages Hosting
+
+This repository includes a GitHub Actions workflow that exports the app for the web
+and deploys it to GitHub Pages whenever changes are pushed to the `main` branch.
+
+1. Ensure GitHub Pages is enabled on your repository.
+2. Push to the `main` branch and the workflow will build and publish the web app.
+
+The emergency number dialed is set to `112`. You can change this in `App.js`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "emergency-face-id-app",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start",
+    "export:web": "expo export --platform web --output-dir web-build"
+  },
+  "dependencies": {
+    "expo": "^50.0.17",
+    "expo-local-authentication": "~14.2.1",
+    "react": "18.1.0",
+    "react-native": "0.72.4"
+  }
+}


### PR DESCRIPTION
## Summary
- provide a GitHub Actions workflow to deploy Expo web build to GitHub Pages
- add export script and ignore generated web build
- document Pages deployment in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68541cdb2a00832da43a0fb14a9f84d9